### PR TITLE
Add inline-source-map-comment to the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,7 @@
 
 > Convert a Source Map object to a comment
 
+Use [inline-source-map-comment](https://github.com/shinnn/inline-source-map-comment) if you need more options. (e.g. CSS source map support)
 
 ## Install
 


### PR DESCRIPTION
https://github.com/shinnn/inline-source-map-comment

It supports some options:
- [Block comment](https://github.com/shinnn/inline-source-map-comment#optionsblock) support for CSS source map
- [Users can choose whether `sourcesContent` property will be preserved or not.](https://github.com/shinnn/inline-source-map-comment#optionssourcescontent)
