### PR TITLE
Accept stringified JSON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,4 @@ sudo: false
 language: node_js
 node_js:
   - '5'
-  - '4'
-  - '0.12'
-  - '0.10'
+  - '6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 sudo: false
 language: node_js
 node_js:
-  - '5'
   - '6'

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 module.exports = function (val, opts) {
 	opts = opts || {};
 
-	var base64 = new Buffer(typeof val === 'string' ? val : JSON.stringify(val)).toString('base64');
+	var base64 = Buffer.from(typeof val === 'string' ? val : JSON.stringify(val)).toString('base64');
 	var contents = 'sourceMappingURL=data:application/json;base64,' + base64;
 
 	if (opts.type === 'css') {

--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@
 module.exports = function (val, opts) {
 	opts = opts || {};
 
-	var base64 = Buffer.from(typeof val === 'string' ? val : JSON.stringify(val)).toString('base64');
-	var contents = 'sourceMappingURL=data:application/json;base64,' + base64;
+	const base64 = Buffer.from(typeof val === 'string' ? val : JSON.stringify(val)).toString('base64');
+	const contents = 'sourceMappingURL=data:application/json;base64,' + base64;
 
 	if (opts.type === 'css') {
 		return '/*# ' + contents + ' */';

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 module.exports = function (val, opts) {
 	opts = opts || {};
 
-	var base64 = new Buffer(JSON.stringify(val)).toString('base64');
+	var base64 = new Buffer(typeof val === 'string' ? val : JSON.stringify(val)).toString('base64');
 	var contents = 'sourceMappingURL=data:application/json;base64,' + base64;
 
 	if (opts.type === 'css') {

--- a/readme.md
+++ b/readme.md
@@ -14,9 +14,12 @@ $ npm install --save source-map-to-comment
 
 ```js
 const sourceMapToComment = require('source-map-to-comment');
-const sourceMap = getSourceMapFromSomething();
+const sourceMap = getSourceMapObjectFromSomething();
 
 sourceMapToComment(sourceMap);
+//=> '//# sourceMappingURL=data:application/json;base64,eyJ2Z...'
+
+sourceMapToComment(JSON.stringify(sourceMap));
 //=> '//# sourceMappingURL=data:application/json;base64,eyJ2Z...'
 
 sourceMapToComment(sourceMap, {type: 'css'});

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import m from './';
+import m from '.';
 
 const sourceMapFixture = {
 	version: 3,

--- a/test.js
+++ b/test.js
@@ -19,6 +19,13 @@ test('main', t => {
 	);
 });
 
+test('string argument', t => {
+	t.is(
+		m(sourceMapFixture),
+		m(JSON.stringify(sourceMapFixture))
+	);
+});
+
 test('type option', t => {
 	t.regex(
 		m(sourceMapFixture, {type: 'css'}),


### PR DESCRIPTION
[SWC](https://ghub.io/swc) returns source-maps as JSON. In order to make source-map-to-comment take them, they need parsing first.
This PR makes sourcemap-to-comment recognize strings directly, allowing to skip extra JSON parsing/stringifying step.